### PR TITLE
Add support for Basic Auth to V2 registries

### DIFF
--- a/squid.conf.template
+++ b/squid.conf.template
@@ -9,7 +9,7 @@ range_offset_limit 8 GB
 quick_abort_min -1
 cache_dir ufs /cache/cc {{ cache_size }} 16 256
 
-cache_peer {{ docker_host }} parent 443 0 no-query originserver no-digest name=upstream ssl sslflags=DONT_VERIFY_PEER
+cache_peer {{ docker_host }} parent 443 0 no-query originserver no-digest name=upstream login=PASSTHRU ssl sslflags=DONT_VERIFY_PEER
 
 acl site dstdomain {{ docker_host }}
 http_access allow site


### PR DESCRIPTION
Solves the authentication issue from #6 where you were unable to run `docker login` and have it proxied.